### PR TITLE
ucentral-client: reject wildcard certs matching multi-level subdomains

### DIFF
--- a/main.c
+++ b/main.c
@@ -89,6 +89,7 @@ validate_CN(char *CN)
 	int CN_len;
 	int server_len;
 	int ret;
+	int prefix_len;
 
 	if (!strcmp(client.server, CN))
 		return 0;
@@ -103,10 +104,16 @@ validate_CN(char *CN)
 
 	ret = strcmp(&CN[1], &client.server[server_len - CN_len + 1]);
 
-	if (!ret)
-		ULOG_INFO("server is using a wildcard certificate\n");
+	if (ret)
+		return ret;
 
-	return ret;
+	prefix_len = server_len - CN_len + 1;
+	if (memchr(client.server, '.', prefix_len))
+		return -1;
+
+	ULOG_INFO("server is using a wildcard certificate\n");
+
+	return 0;
 }
 
 static void


### PR DESCRIPTION
Per RFC 6125, a wildcard certificate like *.example.com should only match a single DNS label (e.g. foo.example.com), not multi-level subdomains (e.g. foo.bar.example.com). The existing validate_CN() only checked that the server name ended with the wildcard's domain suffix, allowing multi-level matches. Add a check that the prefix portion replacing the wildcard contains no dots.

Fixes WIFI-15386